### PR TITLE
Output s3 bucket arn from the state-store module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Examples are provided in the `examples/` directory for common use cases:
 | shared\_agent\_security\_group | Shared agent security group optional to be passed into all agent node pools |
 | shared\_server\_security\_group | Shared server security group required to be passed into all server node pools |
 | state\_bucket | Name of the bucket used to store k3s cluster state, required to be passed in to node pools |
+| state\_bucket\_arn | ARN of the bucket used to store k3s cluster state, if it was created. Null will be outputted if the module did not create the bucket. |
 | state\_key | Name of the state object used to store k3s cluster state |
 | tls\_san | DNS of the control plane load balancer, used for passing --tls-san to server nodepools |
 | token | Token used for k3s --token registration, added for brevity, does not need to be passed to module, it is loaded via S3 state bucket |

--- a/modules/state-store/outputs.tf
+++ b/modules/state-store/outputs.tf
@@ -1,3 +1,7 @@
 output "bucket" {
   value = aws_s3_bucket.state.bucket
 }
+
+output "arn" {
+  value = aws_s3_bucket.state.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,6 +63,11 @@ output "state_bucket" {
   description = "Name of the bucket used to store k3s cluster state, required to be passed in to node pools"
 }
 
+output "state_bucket_arn" {
+  value       = var.state_bucket == null ? module.state[0].arn : null
+  description = "ARN of the bucket used to store k3s cluster state, if it was created. Null will be outputted if the module did not create the bucket."
+}
+
 output "state_key" {
   value       = aws_s3_bucket_object.state.key
   description = "Name of the state object used to store k3s cluster state"


### PR DESCRIPTION
Outputs the s3 bucket's arn if it was created.  A bit gross since the output will be null if an already created bucket was provided. 