### PR TITLE
AWS CCM: Add "Exists" operator to role/master toleration

### DIFF
--- a/modules/nodepool/files/aws-ccm.yaml
+++ b/modules/nodepool/files/aws-ccm.yaml
@@ -139,6 +139,7 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: "Exists"
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager


### PR DESCRIPTION
AWS CCM is currently not properly being scheduled on server nodes if
they are started with a tain of Effect "NoSchedule" on the master
node-role.  Tracked it down to the ccm daemon set not having the Exists
operator on it's toleration for this taint.